### PR TITLE
Docker run $(RM) is not properly evaluated

### DIFF
--- a/zombietest/Makefile
+++ b/zombietest/Makefile
@@ -15,7 +15,7 @@ runsvinit: ../*.go
 	env GOOS=linux GOARCH=amd64 $(GO) build -o $@ github.com/peterbourgon/runsvinit
 
 zombie: .build.uptodate
-	$(SUDO) docker run $(RM) -v $(shell pwd):/mount zombietest-build cc -Wall -Werror -o /mount/zombie /zombie.c
+	$(SUDO) docker run $$RM -v $(shell pwd):/mount zombietest-build cc -Wall -Werror -o /mount/zombie /zombie.c
 
 .build.uptodate: build/zombie.c build/Dockerfile
 	$(SUDO) docker build -t zombietest-build build/


### PR DESCRIPTION
Hi Peter,
Running the test cases I found that $(RM) is not being properly evaluated, see log:

``` go
docker run rm -f -v /Users/sgm/projects/gocode/src/github.com/peterbourgon/runsvinit/zombietest:/mount zombietest-build cc -Wall -
Werror -o /mount/zombie /zombie.c
```

As you may notice, tries to run `docker run rm`, the dashes are missing. I tested in Ubuntu 14.04 and OSX 10.10. Now it's working.
